### PR TITLE
add numeric column type

### DIFF
--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -52,6 +52,7 @@ class PostgresToRedshift::Column
     "jsonb" => "CHARACTER VARYING(65535)",
     "bytea" => "CHARACTER VARYING(65535)",
     "money" => "DECIMAL(19,2)",
+    "numeric" => "DECIMAL(19,2)",
     "oid" => "CHARACTER VARYING(65535)",
     "ARRAY" => "CHARACTER VARYING(65535)",
     "USER-DEFINED" => "CHARACTER VARYING(65535)",


### PR DESCRIPTION
Adds the numeric column type to CAST_TYPES_FOR_COPY. This is required to get the correct decimal precision. Without this change, all numeric types in postgres get copied over with no precision, and therefore rounded values!